### PR TITLE
[Build] Linux on Travis CI

### DIFF
--- a/EMULATOR/EMULATOR.C
+++ b/EMULATOR/EMULATOR.C
@@ -1692,7 +1692,7 @@ ShaderID Shader_Compile_Internal(const DWORD *vs_data, const DWORD *ps_data)
 	assert(!FAILED(hr));
 	return shader;
 }
-#elif
+#else
     #error
 #endif
 
@@ -2109,7 +2109,7 @@ void Emulator_SetShader(const ShaderID &shader)
 #elif defined(D3D9)
 	d3ddev->SetVertexShader(shader.VS);
 	d3ddev->SetPixelShader(shader.PS);
-#elif
+#else
 	#error
 #endif
 
@@ -2154,7 +2154,7 @@ void Emulator_DestroyTexture(TextureID texture)
     glDeleteTextures(1, &texture);
 #elif defined(D3D9)
     texture->Release();
-#elif
+#else
     #error
 #endif
 }
@@ -2741,7 +2741,7 @@ void Emulator_SetRenderTarget(const RenderTargetID &frameBufferObject)
 	glBindFramebuffer(GL_FRAMEBUFFER, frameBufferObject);
 #elif defined(D3D9)
 	d3ddev->SetRenderTarget(0, frameBufferObject);
-#elif defined(VK)
+#else
     #error
 #endif
 }

--- a/SPEC_PSXPC_N/PLATFORM/Linux.cmake
+++ b/SPEC_PSXPC_N/PLATFORM/Linux.cmake
@@ -16,11 +16,11 @@ include_directories(${SDL2_INCLUDE_DIR})
 
 set(PSX_LIB Emulator_${TARGET_ARCH})
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-narrowing -std=c++11")
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wno-narrowing -std=c++11")
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wno-narrowing -std=c++11")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing -std=c++11")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-narrowing -std=c++11")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-narrowing -std=c++11")
+set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -fpermissive -Wno-narrowing -std=c++11")
+set(CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} -fpermissive -Wno-narrowing -std=c++11")
+set(CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE} -fpermissive -Wno-narrowing -std=c++11")
+set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -fpermissive -Wno-narrowing -std=c++11")
+set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -fpermissive -Wno-narrowing -std=c++11")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fpermissive -Wno-narrowing -std=c++11")
 
 endif()


### PR DESCRIPTION
It looks like recent gcc ignores empty `#elif`statement if one of earlier conditionals evaluated non-zero. However Travis CI uses gcc4 which is strict about this.